### PR TITLE
Allow opening other Launchpad devices

### DIFF
--- a/src/clj_launchpad.clj
+++ b/src/clj_launchpad.clj
@@ -62,17 +62,20 @@
   ([lpad intensity]
     (send-midi lpad 0xb0 0 (+ (intensity intensities) 0x7c))))
 
-(defn open [] 
-  "find the launchpad in the available midi devices and return a launchpad object suitable
-  for the calls of this library"
+(defn
+  (open []
+        "find the launchpad name \"Launchpad\" in the available midi devices and return a launchpad object suitable for the calls of this library"
+        (open "Launchpad"))
+  (open [name]
+  "find the launchpad by name in the available midi devices and return a launchpad object suitable for the calls of this library"
   (let [[in-device out-device]
-           (sort-by #(.getMaxTransmitters % ) 
-                    (map #(MidiSystem/getMidiDevice %) 
-                  (filter #(= "Launchpad" (.getName %)) (MidiSystem/getMidiDeviceInfo)))) 
+        (sort-by #(.getMaxTransmitters % )
+                 (map #(MidiSystem/getMidiDevice %)
+                      (filter #(= name (.getName %)) (MidiSystem/getMidiDeviceInfo))))
         out (.getReceiver out-device)
         in (.getTransmitter in-device)
-        lpad {:in-device in-device 
-              :out-device out-device 
+        lpad {:in-device in-device
+              :out-device out-device
               :in in
               :out out}]
     (do 

--- a/src/clj_launchpad.clj
+++ b/src/clj_launchpad.clj
@@ -62,6 +62,10 @@
   ([lpad intensity]
     (send-midi lpad 0xb0 0 (+ (intensity intensities) 0x7c))))
 
+(defn midi-device-names []
+  "returns names of available Midi devices, usable with the open function"
+  (map #(.getName %) (MidiSystem/getMidiDeviceInfo)))
+
 (defn
   (open []
         "find the launchpad name \"Launchpad\" in the available midi devices and return a launchpad object suitable for the calls of this library"


### PR DESCRIPTION
I have a [Launchpad Mini](global.novationmusic.com/launch/launchpad-mini) which was not recognized by `clj-launchpad`. That is because the it identifies itself as `Launchpad Mini` as can be seen from the following REPL output

``` clojure
user> (map #(.getName %) (javax.sound.midi.MidiSystem/getMidiDeviceInfo))
("Gervill" "Launchpad Mini" "Launchpad Mini" "Real Time Sequencer")
```

I changed the `open` function to accept a device name, defaulting to `Launchpad`. I also created a function to return the available midi device names, basically naming the above function `midi-device-names`.
